### PR TITLE
Fixes to customize command and example script

### DIFF
--- a/scripts/customize.py
+++ b/scripts/customize.py
@@ -136,7 +136,7 @@ def build_custom_reference(subject, genotype, grouping, transcriptome_type, temp
      
     for transcript in transcriptome:
         allele_idx[str(idx)] = transcript.id
-        lengths[str(idx)] = len(seq)
+        lengths[str(idx)] = len(transcript.seq)
 
         record = SeqRecord(transcript.seq,
                            id=str(idx),

--- a/scripts/customize.py
+++ b/scripts/customize.py
@@ -63,6 +63,7 @@ __date__        = '2019-04-02'
 rootDir            = os.path.dirname(os.path.realpath(__file__)) + '/../'
 cDNA_p             = rootDir + 'dat/ref/cDNA.p'
 cDNA_single_p      = rootDir + 'dat/ref/cDNA.single.p'
+allele_groups_p    = rootDir + 'dat/ref/allele_groups.p'
 GRCh38_chr6        = rootDir + 'dat/ref/GRCh38.chr6.noHLA.fasta'
 GRCh38             = rootDir + 'dat/ref/GRCh38.all.noHLA.fasta'
 HLA_json           = rootDir + 'dat/ref/hla_transcripts.json'
@@ -91,7 +92,7 @@ def build_custom_reference(subject, genotype, grouping, transcriptome_type, temp
         for transcript in HLA_transcripts[gene]:
             transcriptome.append(dummy_HLA_dict[transcript])
      
-    with open('dat/ref/allele_groups.p','rb') as file:
+    with open(allele_groups_p,'rb') as file:
         groups = pickle.load(file)
     with open(cDNA_p,'rb') as file:
         cDNA = pickle.load(file)    

--- a/test/run_quant_test.sh
+++ b/test/run_quant_test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -Eeuxo pipefail
+
+## This script downloads one example BAM and runs the entire processing including quantification.
+## It is meant to be used during development.
+## Instructions: 
+## - Checkout the repository and the required branch
+## - Build the Docker image by running this from the repo directory: docker build -t arcashla-gen -f Docker/Dockerfile . 
+## - Change to some empty directory outside of the repo and execute this script by its full path from the repo source
+
+this_dir=$(cd $(dirname $0) && pwd)
+HOST_SRC=$(cd $this_dir/.. && pwd)
+
+## Download one sample BAM from 1000 genomes Geuvadis dataset used in the arcasHLA publication https://doi.org/10.1093/bioinformatics/btz474
+curl -o HG00096.1.M_111124_6.bam https://www.ebi.ac.uk/arrayexpress/files/E-GEUV-1/HG00096.1.M_111124_6.bam
+
+## Expected HLA calls can be found, for example, here:
+## https://github.com/genevol-usp/phasetools/blob/master/input/hla_genotypes.tsv
+
+## where host pwd will be bind-mounted inside docker container
+DOCKER_DIR=/home/work
+
+## outputs of different stages inside container
+DOCKER_EXTRACT_DIR=$DOCKER_DIR/extract
+DOCKER_GENOTYPE_DIR=$DOCKER_DIR/genotype
+DOCKER_QUANTREF_DIR=$DOCKER_DIR/quantref
+
+## final quantification outputs inside docker - corresponds to `pwd`/quant
+DOCKER_QUANT_DIR=$DOCKER_DIR/quant
+
+## this is development script, so we bind mount `scripts` directory from host to avoid rebuilding the image on every code edit
+DOCKER_BASE_CMD="docker run --rm -v `pwd`:$DOCKER_DIR -v $HOST_SRC/scripts:/home/arcasHLA-quant/scripts arcashla-gen:latest arcasHLA"
+
+## extract chrom 6 from BAM
+$DOCKER_BASE_CMD extract --paired $DOCKER_DIR/HG00096.1.M_111124_6.bam --outdir $DOCKER_EXTRACT_DIR
+
+## genotype
+$DOCKER_BASE_CMD genotype --outdir $DOCKER_GENOTYPE_DIR \
+ $DOCKER_EXTRACT_DIR/HG00096.1.M_111124_6.extracted.1.fq.gz \
+ $DOCKER_EXTRACT_DIR/HG00096.1.M_111124_6.extracted.2.fq.gz
+
+## build custom reference for quantification
+$DOCKER_BASE_CMD customize --genes A,B,C --transcriptome chr6 --genotype $DOCKER_GENOTYPE_DIR/HG00096.genotype.json --outdir $DOCKER_QUANTREF_DIR
+
+## quantify
+$DOCKER_BASE_CMD quant --ref $DOCKER_QUANTREF_DIR/HG00096 --outdir $DOCKER_QUANT_DIR \
+ $DOCKER_EXTRACT_DIR/HG00096.1.M_111124_6.extracted.1.fq.gz \
+ $DOCKER_EXTRACT_DIR/HG00096.1.M_111124_6.extracted.2.fq.gz
+


### PR DESCRIPTION
Even after the #1 , the `customize` command would not run. I have made a couple of trivial fixes to get it running.
One of the fixes that I had to make suggested that it never ran to completion before. I do not know if it runs correctly now - it just completes. 

I have read your [preprint](https://www.medrxiv.org/content/10.1101/2020.09.30.20204875v1) with great interest. Very useful new functionality! Hopefully, the reviewers will ask for some synthetic or real ground truth datasets to verify correctness of the relative allele quantification.

I have included a simple end-to-end example script to at least see that it can run all steps to completion.